### PR TITLE
fix typo

### DIFF
--- a/autoload/easyCO.vim
+++ b/autoload/easyCO.vim
@@ -139,7 +139,7 @@ function! easyCO#IsCommentOut()
 endfunction
 "コメントアウト実行"
 function! easyCO#SwitchCom() range
-  echo a:firstline . ' ' . a:lastline
+  "echo a:firstline . ' ' . a:lastline
   if a:lastline - a:firstline <= 0
     if easyCO#IsCommentOut() == 1
       exec ":call easyCO#Ucom(" . a:firstline . "," . a:lastline . ")"


### PR DESCRIPTION
`cmdheight=0` に設定した場合、出力が収まりきらないことにより

```
press enter or type command to continue
```

が表示されます

この修正点は私にとってデバッグ時のメッセージのように見えます